### PR TITLE
Clear report before generating next one

### DIFF
--- a/number_speed.py
+++ b/number_speed.py
@@ -102,3 +102,4 @@ class NumberSpeedAccuracy:
         time_format = "%H-%M_%d-%m-%Y"
         date_time = time_now.strftime(time_format)
         pdf.output(f'reports/{date_time}_number_speed_report.pdf', 'F')
+        self.report.clear()

--- a/perceptual_speed.py
+++ b/perceptual_speed.py
@@ -125,3 +125,4 @@ class PerceptualSpeed:
         time_format = "%H-%M_%d-%m-%Y"
         date_time = time_now.strftime(time_format)
         pdf.output(f'reports/{date_time}_perceptual_speed_report.pdf', 'F')
+        self.report.clear()

--- a/reasoning.py
+++ b/reasoning.py
@@ -135,3 +135,4 @@ class Reasoning:
         time_format = "%H-%M_%d-%m-%Y"
         date_time = time_now.strftime(time_format)
         pdf.output(f'reports/{date_time}_reasoning_report.pdf', 'F')
+        self.report.clear()

--- a/spatial_visualisation.py
+++ b/spatial_visualisation.py
@@ -116,3 +116,4 @@ class SpatialVisualisation:
         time_format = "%H-%M_%d-%m-%Y"
         date_time = time_now.strftime(time_format)
         pdf.output(f'reports/{date_time}_spatial_visualisation_report.pdf', 'F')
+        self.report.clear()

--- a/word_meaning.py
+++ b/word_meaning.py
@@ -97,3 +97,4 @@ class WordMeaning:
         time_format = "%H-%M_%d-%m-%Y"
         date_time = time_now.strftime(time_format)
         pdf.output(f'reports/{date_time}_word_meaning_report.pdf', 'F')
+        self.report.clear()


### PR DESCRIPTION
This fixes reports from multiple exercises (of the same type) being appended to one another when generated during a single session with the app. See the screenshot for an illustration of how the latest report would contain results from previous exercise runs, too.
![image](https://github.com/DanielM24/GIA-Practice-Tests/assets/6623103/f99b249f-a046-4f79-875e-b3866175cc80)
